### PR TITLE
[FIX] base/saas~17.5: handle missing field_type for company_dependent

### DIFF
--- a/LCproblems/probVowels.java
+++ b/LCproblems/probVowels.java
@@ -29,6 +29,7 @@ public class probVowels {
 
     public static String swap(String m , int a, int b){
         char[] l = m.toCharArray();
+
         char temp = l[a];
         l[a] = l[b];
         l[b] = temp;

--- a/LCproblems/probVowels.java
+++ b/LCproblems/probVowels.java
@@ -10,7 +10,7 @@ public class probVowels {
         int i = 0, j = k-1;
 
         while(i<j){
-            while(i<j && !isVowel(s.charAt(i))){
+            while(i<j  && !isVowel(s.charAt(i))){
                 i++;
             }
             while(i<j && !isVowel(s.charAt(j))){


### PR DESCRIPTION
fields

With the migration to v18, significant changes were introduced to handle data
migration for company-dependent fields from `ir_property` to the `jsonb` column.
While most field types were addressed in the upgrade script, `datetime` fields
were missing, leading to a traceback during migration.

This commit resolves the issue by adding support for `datetime` field types in
the upgrade script. The fix ensures smooth migration for databases with custom
 company-dependent fields of type `datetime`.

 => Reason for the fix:
 - A customer encountered a migration failure due to a custom company-dependen OPW-4434022
UPG-2403978